### PR TITLE
Remove non-Fedora-compliant Intel "EXPORT LAWS" clause from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -31,13 +31,3 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
-
-EXPORT LAWS: THIS LICENSE ADDS NO RESTRICTIONS TO THE EXPORT LAWS OF YOUR
-JURISDICTION. It is licensee's responsibility to comply with any export
-regulations applicable in licensee's jurisdiction. Under CURRENT (May 2000)
-U.S. export regulations this software is eligible for export from the U.S.
-and can be downloaded by or otherwise exported or reexported worldwide EXCEPT
-to U.S. embargoed destinations which include Cuba, Iraq, Libya, North Korea,
-Iran, Syria, Sudan, Afghanistan and any other country to which the U.S. has
-embargoed goods and services.
-


### PR DESCRIPTION
## Why

Red Hat Legal (`rfontana`) flagged this in [Bugzilla #2316327](https://bugzilla.redhat.com/show_bug.cgi?id=2316327) (comments 12, 20-23) as the deprecated, non-Fedora-allowed **SPDX `Intel`** license — an export-control notice historically layered on top of our BSD-3-Clause text — which has never gone through Fedora's [license-review-process](https://docs.fedoraproject.org/en-US/legal/license-review-process/) and is currently the single biggest blocker on the `opa-fm` Fedora package review (JIRA STL-69721).

Reviewer Benson Muite [confirmed](https://bugzilla.redhat.com/show_bug.cgi?id=2316327#c25) on 2026-05-16 he's "happy to finish the review once licensing/re-licensing is resolved."

Dennis noted in comment 23 that these files were deleted and "we can probably just change the license text since we own it as part of our spin out from Intel" — this PR performs that removal against the actual `fedora` branch (no such commit had landed there previously).

## What changed

- `LICENSE`: removed the `EXPORT LAWS: ... U.S. embargoed destinations which include Cuba, Iraq, Libya, North Korea, Iran, Syria, Sudan, Afghanistan ...` paragraph. Remaining GPLv2/BSD-3-Clause licensing text is unchanged.

## Not in scope (tracked separately)

- Rawhide COPR build failure (build 8699982, log now expired/unavailable) — needs a fresh COPR trigger once this lands to see current failure state.
- lib vs lib64 path inconsistency in `%files` (Benson Muite comment 10) — worth re-checking despite PR #33 (LIBDIR patch) having merged.

Ref: JIRA STL-69721 "Get FF and FM into Fedora"